### PR TITLE
Completing WebHDFS REST API 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "PHP WebHDFS, forked from https://github.com/simpleenergy/php-WebHDFS",
   "minimum-stability": "stable",
   "license": "MIT",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "authors": [
     {
       "name": "tranch-xiao",


### PR DESCRIPTION
Small details are missing from WebHDFS REST API at http://hadoop.apache.org/docs/current/hadoop-project-dist/hadoop-hdfs/WebHDFS.html#Concat_Files

This PR completes the missing parts from the two major sections of the API:
- File and Directory Operations
- Other File System Operations

@Degola  I've added the following to the library:

- Complete options for the create/createWithData methods
- add the following missing methods from the specs:
-- truncate
-- getTrashRoot
-- modifyAclEntries
-- removeAclEntries
-- removeDefaultAcl
-- removeAcl
-- setAcl
-- getAclStatus
-- checkAccess

Think I can get maintainer access to the `simpleenergy/php-webhdfs` packagist https://packagist.org/packages/simpleenergy/php-webhdfs as I am now the GitHub maintainer of this library?